### PR TITLE
Add bash args to optionally load local cyclone_dds

### DIFF
--- a/cyclone_dds.xml
+++ b/cyclone_dds.xml
@@ -2,6 +2,11 @@
 <CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config
 https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
     <Domain id="any">
+        <General>
+            <Interfaces>
+              <NetworkInterface name="enp129s0f1" />
+            </Interfaces>
+        </General>
         <Internal>
             <SocketReceiveBufferSize min="10MB"/>
         </Internal>

--- a/dev.sh
+++ b/dev.sh
@@ -3,6 +3,59 @@
 # Build docker dev stage and add local code for live development
 # ----------------------------------------------------------------
 
+CYCLONE_VOL=""
+BASH_CMD=""
+
+# Default cyclone_dds.xml path
+CYCLONE_DIR=/home/$USER/cyclone_dds.xml
+
+# Function to print usage
+usage() {
+    echo "
+Usage: dev.sh [-b|bash] [-l|--local] [-h|--help]
+
+Where:
+    -b | bash       Open bash in docker container (Default in dev.sh)
+    -l | --local    Use default local cyclone_dds.xml config
+    -l | --local    Optionally point to absolute -l /path/to/cyclone_dds.xml
+    -h | --help     Show this help message
+    "
+    exit 1
+}
+
+# Parse command-line options
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -b|bash)
+            BASH_CMD=bash
+            ;;
+        -l|--local)
+            # Avoid getting confused if bash is written where path should be
+            if [ -n "$2" ]; then
+                if [ ! $2 = "bash" ]; then
+                    CYCLONE_DIR="$2"
+                    shift
+                fi
+            fi
+            CYCLONE_VOL="-v $CYCLONE_DIR:/opt/ros_ws/cyclone_dds.xml"
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+    shift
+done
+
+# Verify CYCLONE_DIR exists
+if [ ! -f "$CYCLONE_DIR" ]; then
+    echo "$CYCLONE_DIR does not exist! Please provide a valid path to cyclone_dds.xml"
+    exit 1
+fi
+
 # Build docker image up to dev stage
 DOCKER_BUILDKIT=1 docker build \
     -t av_velodyne:latest-dev \
@@ -10,7 +63,9 @@ DOCKER_BUILDKIT=1 docker build \
 
 # Run docker image with local code volumes for development
 docker run -it --rm --net host --privileged \
-    -v /dev/shm:/dev/shm \
+    -v /dev:/dev \
+    -v /tmp:/tmp \
     -v /etc/localtime:/etc/localtime:ro \
     -v ./av_velodyne_launch:/opt/ros_ws/src/av_velodyne_launch \
+    $CYCLONE_VOL \
     av_velodyne:latest-dev

--- a/runtime.sh
+++ b/runtime.sh
@@ -3,12 +3,57 @@
 # Build docker image and run ROS code for runtime or interactively with bash
 # ---------------------------------------------------------------------------
 
-# Initialise CMD as empty
-CMD=""
+CYCLONE_VOL=""
+BASH_CMD=""
 
-# If an arg is defined, start container with bash
-if [ -n "$1" ]; then
-    CMD="bash"
+# Default cyclone_dds.xml path
+CYCLONE_DIR=/home/$USER/cyclone_dds.xml
+
+# Function to print usage
+usage() {
+    echo "
+Usage: dev.sh [-b|bash] [-l|--local] [-h|--help]
+
+Where:
+    -b | bash       Open bash in docker container (Default in dev.sh)
+    -l | --local    Use default local cyclone_dds.xml config
+    -l | --local    Optionally point to absolute -l /path/to/cyclone_dds.xml
+    -h | --help     Show this help message
+    "
+    exit 1
+}
+
+# Parse command-line options
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -b|bash)
+            BASH_CMD=bash
+            ;;
+        -l|--local)
+            # Avoid getting confused if bash is written where path should be
+            if [ -n "$2" ]; then
+                if [ ! $2 = "bash" ]; then
+                    CYCLONE_DIR="$2"
+                    shift
+                fi
+            fi
+            CYCLONE_VOL="-v $CYCLONE_DIR:/opt/ros_ws/cyclone_dds.xml"
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+    shift
+done
+
+# Verify CYCLONE_DIR exists
+if [ ! -f "$CYCLONE_DIR" ]; then
+    echo "$CYCLONE_DIR does not exist! Please provide a valid path to cyclone_dds.xml"
+    exit 1
 fi
 
 # Build docker image only up to base stage
@@ -18,6 +63,8 @@ DOCKER_BUILDKIT=1 docker build \
 
 # Run docker image without volumes
 docker run -it --rm --net host --privileged \
-    -v /dev/shm:/dev/shm \
+    -v /dev:/dev \
+    -v /tmp:/tmp \
     -v /etc/localtime:/etc/localtime:ro \
+    $CYCLONE_VOL \
     av_velodyne:latest $CMD


### PR DESCRIPTION
 - Update dev.sh and runtime.sh scripts to optionally load cyclone_dds.xml
 - By default, container will use cyclone_dds.xml from repository
 - With -l|--local argument with no path by default points to /home/$user/cyclone_dds.xml
 - Also refresh script with better help and bash functionality
 - Also also update cyclone_dds.xml to use AV ethernet interface